### PR TITLE
Show better command line task titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This is the brief changelog. For more details see https://github.com/andywer/npm
 
 - Breaking change: Running `launch` without parameters now shows the available tasks
 - Much shorter init time for JSON-based configs (1.4s faster (!))
+- Better command line task titles (`git push` instead of `git`, ...)
 
 ## v0.3.0
 

--- a/lib/loaders/json.js
+++ b/lib/loaders/json.js
@@ -53,7 +53,7 @@ function createTaskForSubCommand (subCommand, taskName) {
     const title = subCommand.length > 30 ? subCommand.substr(0, 30) + '...' : subCommand
     return createAnonymousConcurrencyTask(spaceSeparatedSubTasks, taskName, title)
   } else {
-    const title = subCommand.replace(/\s.*$/, '')
+    const title = createCommandTitle(subCommand)
     return createAnonymousCommandTask(title, () => shellObservable(subCommand))
   }
 }
@@ -68,6 +68,22 @@ function createAnonymousConcurrencyTask (spaceSeparatedSubTasks, taskName, title
     (subTaskName) => createTaskReference(subTaskName, taskName)
   )
   return createAnonymousConcurrentTaskFork(taskName, title, taskReferences)
+}
+
+/**
+ * Takes a shell command string and returns a short, concise task title based on
+ * the command string. Drops command line arguments starting with a dash.
+ */
+function createCommandTitle (commandString) {
+  const args = commandString.split(' ')
+  const command = args[0]
+  const firstParam = args.length > 1 ? args[1] : ''
+
+  if (firstParam && firstParam.charAt(0) !== '-' && (command + firstParam).length <= 10) {
+    return `${command} ${firstParam}`
+  } else {
+    return command
+  }
 }
 
 exports.loadFile = loadFile

--- a/lib/loaders/test/json.test.js
+++ b/lib/loaders/test/json.test.js
@@ -92,7 +92,7 @@ test('task "willFail"', (t) => {
 
     take(task.children[0], (subTask) => {
       t.true(subTask instanceof taskClasses.AnonymousCommandTask)
-      t.is(subTask.title, 'git')
+      t.is(subTask.title, 'git push')
     })
   })
 })
@@ -124,7 +124,7 @@ test('task "parallel"', (t) => {
   })
 })
 
-test('it actually run shell commands', (t) => {
+test('tasks actually run shell commands', (t) => {
   ///////////////////
   // Task "willWork"
 


### PR DESCRIPTION
`git push` instead of `git`
`npm start` instead of `npm`
